### PR TITLE
feat: prohibit reusing IDs of reversed cash-outs

### DIFF
--- a/contracts/Cashier.sol
+++ b/contracts/Cashier.sol
@@ -784,8 +784,6 @@ contract Cashier is
                 revert Cashier_CashInStatusInappropriate();
             if (err == uint256(ICashierShardPrimary.Error.InappropriateCashOutStatus))
                 revert Cashier_CashOutStatusInappropriate();
-            if (err == uint256(ICashierShardPrimary.Error.InappropriateCashOutAccount))
-                revert Cashier_CashOutAccountInappropriate();
             revert Cashier_ShardErrorUnexpected(err);
         }
     }

--- a/contracts/CashierShard.sol
+++ b/contracts/CashierShard.sol
@@ -310,13 +310,7 @@ contract CashierShard is CashierShardStorage, OwnableUpgradeable, UUPSExtUpgrade
         CashOutOperation storage operation = _cashOutOperations[txId];
 
         if (operation.status != CashOutStatus.Nonexistent) {
-            if (operation.status == CashOutStatus.Reversed) {
-                if (operation.account != account) {
-                    return (uint256(Error.InappropriateCashOutAccount), operation.flags);
-                }
-            } else {
-                return (uint256(Error.InappropriateCashOutStatus), operation.flags);
-            }
+            return (uint256(Error.InappropriateCashOutStatus), operation.flags);
         }
 
         operation.account = account;

--- a/contracts/base/Versionable.sol
+++ b/contracts/base/Versionable.sol
@@ -16,6 +16,6 @@ abstract contract Versionable is IVersionable {
      * @inheritdoc IVersionable
      */
     function $__VERSION() external pure returns (Version memory) {
-        return Version(4, 1, 0);
+        return Version(4, 2, 0);
     }
 }

--- a/contracts/interfaces/ICashier.sol
+++ b/contracts/interfaces/ICashier.sol
@@ -25,9 +25,6 @@ interface ICashierErrors {
     /// @dev Thrown if the cash-in operation with the provided txId has an inappropriate status.
     error Cashier_CashInStatusInappropriate();
 
-    /// @dev Thrown if the cash-out operation cannot be executed for the provided account and txId.
-    error Cashier_CashOutAccountInappropriate();
-
     /// @dev Thrown if the cash-out operation with the provided txId has an inappropriate status.
     error Cashier_CashOutStatusInappropriate();
 

--- a/contracts/interfaces/ICashierShard.sol
+++ b/contracts/interfaces/ICashierShard.sol
@@ -31,14 +31,12 @@ interface ICashierShardPrimary is ICashierTypes {
      * - CashInAlreadyExecuted = 1 -------- The cash-in operation has already been executed.
      * - InappropriateCashInStatus = 2 ---- The cash-in operation status is inappropriate.
      * - InappropriateCashOutStatus = 3 --- The cash-out operation status is inappropriate.
-     * - InappropriateCashOutAccount = 4 -- The cash-out operation account is inappropriate.
      */
     enum Error {
         None,
         CashInAlreadyExecuted,
         InappropriateCashInStatus,
-        InappropriateCashOutStatus,
-        InappropriateCashOutAccount
+        InappropriateCashOutStatus
     }
 
     // ------------------ Functions ------------------------------- //

--- a/test/CashierSharded.test.ts
+++ b/test/CashierSharded.test.ts
@@ -210,7 +210,7 @@ describe("Contracts 'Cashier' and `CashierShard`", async () => {
 
   const EXPECTED_VERSION: Version = {
     major: 4,
-    minor: 1,
+    minor: 2,
     patch: 0
   };
 


### PR DESCRIPTION
## Main changes

1. The reversed cash-outs can no longer be re-requested with the same `txId` and account address.
2. The `Reversed` status is now final for a cash-out operation and cannot be changed further.

## Test coverage

Functionality is fully covered by tests.

<details><summary>Test coverage details</summary>
<p>

File                                  |  % Stmts | % Branch |  % Funcs |  % Lines |
--------------------------------------|----------|----------|----------|----------|
 contracts/                           |      100 |    97.53 |      100 |      100 |
 ├─ Cashier.sol                         |      100 |    98.41 |      100 |      100 |
 ├─ CashierShard.sol                    |      100 |    94.44 |      100 |      100 |
 ├─ CashierShardStorage.sol             |      100 |      100 |      100 |      100 |
 ├─ CashierStorage.sol                  |      100 |      100 |      100 |      100 |
 contracts/base/                      |      100 |      100 |      100 |      100 |
 ├─ AccessControlExtUpgradeable.sol     |      100 |      100 |      100 |      100 |
 ├─ PausableExtUpgradeable.sol          |      100 |      100 |      100 |      100 |
 ├─ RescuableUpgradeable.sol            |      100 |      100 |      100 |      100 |
 ├─ UUPSExtUpgradeable.sol              |      100 |      100 |      100 |      100 |
 ├─ Versionable.sol                     |      100 |      100 |      100 |      100 |
 contracts/interfaces/                |      100 |      100 |      100 |      100 |
 ├─ ICashier.sol                        |      100 |      100 |      100 |      100 |
 ├─ ICashierHook.sol                    |      100 |      100 |      100 |      100 |
 ├─ ICashierHookable.sol                |      100 |      100 |      100 |      100 |
 ├─ ICashierShard.sol                   |      100 |      100 |      100 |      100 |
 ├─ ICashierTypes.sol                   |      100 |      100 |      100 |      100 |
 ├─ IERC20Mintable.sol                  |      100 |      100 |      100 |      100 |
 ├─ IVersionable.sol                    |      100 |      100 |      100 |      100 |
 contracts/mocks/                     |      100 |      100 |      100 |      100 |
 ├─ CashierHookMock.sol                 |      100 |      100 |      100 |      100 |
 ├─ CashierShardMock.sol                |      100 |      100 |      100 |      100 |
 contracts/mocks/base/                |      100 |      100 |      100 |      100 |
 ├─ AccessControlExtUpgradeableMock.sol |      100 |      100 |      100 |      100 |
 ├─ PausableExtUpgradeableMock.sol      |      100 |      100 |      100 |      100 |
 ├─ RescuableUpgradeableMock.sol        |      100 |      100 |      100 |      100 |
 ├─ UUPSExtUpgradableMock.sol           |      100 |      100 |      100 |      100 |
 contracts/mocks/tokens/              |      100 |      100 |      100 |      100 |
 ├─ ERC20TokenMock.sol                  |      100 |      100 |      100 |      100 |
--------------------------------------|----------|----------|----------|----------|
All files                             |      100 |    97.94 |      100 |      100 |
--------------------------------------|----------|----------|----------|----------|

</p>
</details> 